### PR TITLE
Profile option added for s3 sync command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ PROFILE={MY-AWS-CLI-PROFILE}
 BUCKET={MY-S3-BUCKET}
 
 copy-config-files:
-	aws s3 sync config s3://$(BUCKET)/blog/config
+	aws s3 sync config s3://$(BUCKET)/blog/config \
+		--profile $(PROFILE)
 
 create-inception-stack:
 	aws cloudformation create-stack \


### PR DESCRIPTION
Profile option added to s3 sync command. Otherwise, credentials from default profile will be used. 
